### PR TITLE
[Sikkerhet] Oppdaterer med catalog-info.yaml til versjon 3.0

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,7 +14,7 @@ spec:
 apiVersion: "backstage.io/v1alpha1"
 kind: "Group"
 metadata:
-  name: "security_champion_topografisk-grunndatabase-produktspesifikasjon"
+  name: "security_champion_topografisk-grunndatabase-produktspesifikasj"
   title: "Security Champion topografisk-grunndatabase-produktspesifikasjon"
 spec:
   type: "security_champion"
@@ -33,6 +33,6 @@ metadata:
     title: "topografisk-grunndatabase-produktspesifikasjon på GitHub"
 spec:
   type: "repo"
-  owner: "security_champion_topografisk-grunndatabase-produktspesifikasjon"
+  owner: "security_champion_topografisk-grunndatabase-produktspesifikasj"
   dependencyOf:
   - "component:topografisk-grunndatabase-produktspesifikasjon"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage, samtidig som `beskrivelse.yaml` nå går til `version: 3.0`.
Det er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.