### PR TITLE
[Sikkerhet] Oppdaterer med ny catalog-info.yaml og engelske filnavn

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/.sikkerhet/ @NilsIvarNes
+/.security/ @NilsIvarNes

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,4 +1,3 @@
-version: 3.0
 organization: Land
 product: PRODSPEK
 repo_types: [Documentation]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -10,29 +10,3 @@ spec:
   lifecycle: "production"
   owner: "topografisk_grunndatabase"
   system: "standardisering"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Group"
-metadata:
-  name: "security_champion_topografisk-grunndatabase-produktspesifikasj"
-  title: "Security Champion topografisk-grunndatabase-produktspesifikasjon"
-spec:
-  type: "security_champion"
-  parent: "land_security_champions"
-  members:
-  - "NilsIvarNes"
-  children:
-  - "resource:topografisk-grunndatabase-produktspesifikasjon"
----
-apiVersion: "backstage.io/v1alpha1"
-kind: "Resource"
-metadata:
-  name: "topografisk-grunndatabase-produktspesifikasjon"
-  links:
-  - url: "https://github.com/kartverket/topografisk-grunndatabase-produktspesifikasjon"
-    title: "topografisk-grunndatabase-produktspesifikasjon på GitHub"
-spec:
-  type: "repo"
-  owner: "security_champion_topografisk-grunndatabase-produktspesifikasj"
-  dependencyOf:
-  - "component:topografisk-grunndatabase-produktspesifikasjon"


### PR DESCRIPTION
Denne PRen oppdaterer `catalog-info.yaml` for å gi entiteter til Backstage. Vi fjerner nå resource og sec. champ hierarkiet. Videre dropper vi å ha versionsnummer i description.yaml